### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,19 @@ jobs:
     strategy:
       matrix:
         os:
-          - "centos-stream-8"
+          - "almalinux-8"
+          - "almalinux-9"
+          - "amazonlinux-2023"
           - "centos-stream-9"
-          - "debian-9"
-          - "debian-10"
-          - "ubuntu-1804"
-          - "ubuntu-2004"
+          - "debian-12"
+          - "debian-13"
+          - "fedora-latest"
+          - "oraclelinux-8"
+          - "oraclelinux-9"
+          - "rockylinux-8"
+          - "rockylinux-9"
+          - "ubuntu-2204"
+          - "ubuntu-2404"
         suite:
           - "default"
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration
     steps:
-      - run: echo ${{needs.integration.outputs}}
+      - run: echo "${{ needs.integration.result }}"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -11,4 +11,4 @@ name: conventional-commits
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -11,6 +11,6 @@ name: prevent-file-change
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,0 @@
-source 'https://supermarket.chef.io'
-cookbook 'testutils', path: './test/fixtures/cookbooks/testutils'
-metadata

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'fileutils'
+
+run_list 'recipe[testutils]'
+
+cookbook 'fileutils', path: '.'
+cookbook 'testutils', path: './test/fixtures/cookbooks/testutils'
+
+Dir.children('./test/fixtures/cookbooks/testutils/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'testutils::' + recipe_name
+end

--- a/README.md
+++ b/README.md
@@ -18,29 +18,33 @@ The fileutils resource will accept two actions.
 * :delete is used to remove files and directories.
   :delete always functions in a recursive mode.
 
-| Action | Parameter | Use
-| ------ | --------- | ---
-| :change | path     | Specify the starting path or file. The path must exist for anything to be done.
-|        | owner    | Set the owner of the files and directories to this value.
-|        | group    | Set the group of the files and directories to this value.
-|        | file_mode | Set the permission mode for files. Specify octal numbers or mode change symbols
-|        | directory_mode | Set the permission mode for directories. Specify octal numbers or mode change symbols
-|        | recursive | Boolean. Use top down traversal from the starting path. Default is true. When recursive is false only the initial directory and contents are changed.
-|        | only_files | Boolean. Only change files. Default is false.
-|        | only_directories | Boolean. Only change directories. Default is false.
-|        | pattern | Regex. Match to filter the basename of files and directories.
-|        | follow_symlink | Boolean. Continue on past symlinks. Very dangerous option with a high risk of changing unintended files. Default is false!
-|        | quiet | Boolean. Suppress output for changing each file. Default is false.
+<!-- markdownlint-disable MD060 -->
 
-| Action | Parameter | Use
-| ------ | --------- | ---
-| :delete | path     | Specify the starting path or file.
-|         | recursive | Delete always functions in recursive mode.
-|         | only_files | Boolean. Only delete files. Default is false.
-|         | pattern | Regex. Match to filter the basename of files and directories.
-|         | follow_symlink | Boolean. Continue on past symlinks. Very dangerous option with a high risk of deleting unintended files. Default is false!
-|         | force | Boolean. Use the for option with FileUtils.
-|         | quiet | Boolean. Supress output for deleting each file. Default is false.
+| Action    | Parameter          | Use                                                                                                                                                   |
+| --------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:change` | `path`             | Specify the starting path or file. The path must exist for anything to be done.                                                                        |
+|           | `owner`            | Set the owner of the files and directories to this value.                                                                                              |
+|           | `group`            | Set the group of the files and directories to this value.                                                                                              |
+|           | `file_mode`        | Set the permission mode for files. Specify octal numbers or mode change symbols.                                                                       |
+|           | `directory_mode`   | Set the permission mode for directories. Specify octal numbers or mode change symbols.                                                                 |
+|           | `recursive`        | Boolean. Use top down traversal from the starting path. Default is true. When recursive is false only the initial directory and contents are changed.  |
+|           | `only_files`       | Boolean. Only change files. Default is false.                                                                                                         |
+|           | `only_directories` | Boolean. Only change directories. Default is false.                                                                                                   |
+|           | `pattern`          | Regex. Match to filter the basename of files and directories.                                                                                         |
+|           | `follow_symlink`   | Boolean. Continue on past symlinks. Very dangerous option with a high risk of changing unintended files. Default is false!                             |
+|           | `quiet`            | Boolean. Suppress output for changing each file. Default is false.                                                                                    |
+
+| Action    | Parameter        | Use                                                                                                                                                   |
+| --------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:delete` | `path`           | Specify the starting path or file.                                                                                                                    |
+|           | `recursive`      | Delete always functions in recursive mode.                                                                                                            |
+|           | `only_files`     | Boolean. Only delete files. Default is false.                                                                                                         |
+|           | `pattern`        | Regex. Match to filter the basename of files and directories.                                                                                         |
+|           | `follow_symlink` | Boolean. Continue on past symlinks. Very dangerous option with a high risk of deleting unintended files. Default is false!                             |
+|           | `force`          | Boolean. Use the for option with FileUtils.                                                                                                           |
+|           | `quiet`          | Boolean. Supress output for deleting each file. Default is false.                                                                                     |
+
+<!-- markdownlint-enable MD060 -->
 
 ## Mode bit settings
 

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -35,7 +35,7 @@ platforms:
   - name: debian-13
     driver:
       image: dokken/debian-13
-      pid_one_command: /bin/systemd
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: fedora-latest
     driver:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -22,54 +22,24 @@ platforms:
       image: dokken/amazonlinux-2023
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-7
-    driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-stream-8
-    driver:
-      image: dokken/centos-stream-8
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-stream-9
     driver:
       image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
-
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-
-  - name: debian-11
-    driver:
-      image: dokken/debian-11
-      pid_one_command: /bin/systemd
 
   - name: debian-12
     driver:
       image: dokken/debian-12
       pid_one_command: /bin/systemd
 
+  - name: debian-13
+    driver:
+      image: dokken/debian-13
+      pid_one_command: /bin/systemd
+
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: opensuse-leap-15
-    driver:
-      image: dokken/opensuse-leap-15
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-7
-    driver:
-      image: dokken/oraclelinux-7
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: oraclelinux-8
@@ -92,22 +62,12 @@ platforms:
       image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-18.04
-    driver:
-      image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
-
-  - name: ubuntu-20.04
-    driver:
-      image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
-
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
 
-  - name: ubuntu-23.04
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-23.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -18,21 +18,13 @@ platforms:
   - name: almalinux-8
   - name: almalinux-9
   - name: amazonlinux-2023
-  - name: centos-7
-  - name: centos-stream-8
   - name: centos-stream-9
-  - name: debian-9
-  - name: debian-10
-  - name: debian-11
   - name: debian-12
+  - name: debian-13
   - name: fedora-latest
-  - name: opensuse-leap-15
-  - name: oraclelinux-7
   - name: oraclelinux-8
   - name: oraclelinux-9
   - name: rockylinux-8
   - name: rockylinux-9
-  - name: ubuntu-18.04
-  - name: ubuntu-20.04
   - name: ubuntu-22.04
-  - name: ubuntu-23.04
+  - name: ubuntu-24.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,7 +16,7 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-20.04
+  - name: ubuntu-24.04
 
 suites:
   - name: default

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -7,6 +7,8 @@
 #
 
 default_action :create
+provides :fileutils
+
 property :path, String, name_property: true
 property :pattern, Regexp
 property :recursive, [true, false], default: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list