### PR TITLE
fix: migrate to Policyfile and clean up docs

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,0 @@
-source 'https://supermarket.chef.io'
-cookbook 'testutils', path: './test/fixtures/cookbooks/testutils'
-metadata

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'fileutils'
+
+run_list 'testutils::default'
+
+cookbook 'fileutils', path: '.'
+cookbook 'testutils', path: './test/fixtures/cookbooks/testutils'
+
+Dir.children('./test/fixtures/cookbooks/testutils/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "testutils::#{recipe_name}"
+end

--- a/README.md
+++ b/README.md
@@ -18,29 +18,29 @@ The fileutils resource will accept two actions.
 * :delete is used to remove files and directories.
   :delete always functions in a recursive mode.
 
-| Action | Parameter | Use
-| ------ | --------- | ---
-| :change | path     | Specify the starting path or file. The path must exist for anything to be done.
-|        | owner    | Set the owner of the files and directories to this value.
-|        | group    | Set the group of the files and directories to this value.
-|        | file_mode | Set the permission mode for files. Specify octal numbers or mode change symbols
-|        | directory_mode | Set the permission mode for directories. Specify octal numbers or mode change symbols
-|        | recursive | Boolean. Use top down traversal from the starting path. Default is true. When recursive is false only the initial directory and contents are changed.
-|        | only_files | Boolean. Only change files. Default is false.
-|        | only_directories | Boolean. Only change directories. Default is false.
-|        | pattern | Regex. Match to filter the basename of files and directories.
-|        | follow_symlink | Boolean. Continue on past symlinks. Very dangerous option with a high risk of changing unintended files. Default is false!
-|        | quiet | Boolean. Suppress output for changing each file. Default is false.
+| Action  | Parameter        | Use                                                                                                                                              |
+| ------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| :change | path             | Specify the starting path or file. The path must exist for anything to be done.                                                                  |
+|         | owner            | Set the owner of the files and directories to this value.                                                                                        |
+|         | group            | Set the group of the files and directories to this value.                                                                                        |
+|         | file_mode        | Set the permission mode for files. Specify octal numbers or mode change symbols.                                                                 |
+|         | directory_mode   | Set the permission mode for directories. Specify octal numbers or mode change symbols.                                                           |
+|         | recursive        | Boolean. Use top down traversal from the starting path. Default is true. When recursive is false only the initial directory and contents change. |
+|         | only_files       | Boolean. Only change files. Default is false.                                                                                                    |
+|         | only_directories | Boolean. Only change directories. Default is false.                                                                                              |
+|         | pattern          | Regex. Match to filter the basename of files and directories.                                                                                    |
+|         | follow_symlink   | Boolean. Continue on past symlinks. Very dangerous option with a high risk of changing unintended files. Default is false!                       |
+|         | quiet            | Boolean. Suppress output for changing each file. Default is false.                                                                               |
 
-| Action | Parameter | Use
-| ------ | --------- | ---
-| :delete | path     | Specify the starting path or file.
-|         | recursive | Delete always functions in recursive mode.
-|         | only_files | Boolean. Only delete files. Default is false.
-|         | pattern | Regex. Match to filter the basename of files and directories.
-|         | follow_symlink | Boolean. Continue on past symlinks. Very dangerous option with a high risk of deleting unintended files. Default is false!
-|         | force | Boolean. Use the for option with FileUtils.
-|         | quiet | Boolean. Supress output for deleting each file. Default is false.
+| Action  | Parameter      | Use                                                                                                                                          |
+| ------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| :delete | path           | Specify the starting path or file.                                                                                                           |
+|         | recursive      | Delete always functions in recursive mode.                                                                                                   |
+|         | only_files     | Boolean. Only delete files. Default is false.                                                                                                |
+|         | pattern        | Regex. Match to filter the basename of files and directories.                                                                                |
+|         | follow_symlink | Boolean. Continue on past symlinks. Very dangerous option with a high risk of deleting unintended files. Default is false!                   |
+|         | force          | Boolean. Use the for option with FileUtils.                                                                                                  |
+|         | quiet          | Boolean. Supress output for deleting each file. Default is false.                                                                            |
 
 ## Mode bit settings
 

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'


### PR DESCRIPTION
## Summary
- replace Berksfile dependency resolution with Policyfile
- switch ChefSpec to Policyfile support
- clean up README table formatting for markdownlint

## Testing
- chef install Policyfile.rb
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH_SYSTEM= /opt/chef-workstation/embedded/bin/rspec --format documentation
- kitchen test default-ubuntu-2204 --destroy=always (run by migration worker; passed)